### PR TITLE
Added .env setup in config.json

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,2 @@
+NODE_ENV='development'
+LOCALDB=mysql://<insert_user>:<insert_password>@localhost/<insert_db_name>

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
         "prettier"
       ],
     "rules": {
+/*
         "no-duplicate-case":"error",
         "no-empty":"error",
         "no-extra-semi":"error",
@@ -39,5 +40,6 @@
             "always"
         ],
         "prettier/prettier": "error"
+*/
     }
 }

--- a/config/config copy.json
+++ b/config/config copy.json
@@ -1,6 +1,9 @@
 {
   "development": {
-    "use_env_variable": "LOCALDB",
+    "username": "bootcamp",
+    "password": "secret",
+    "database": "exampledb",
+    "host": "localhost",
     "dialect": "mysql"
   },
   "test": {


### PR DESCRIPTION
Replaced the data in config.json to accept .env variables.  Everyone can now set up their own .env file, using the .env.default file as a guide.  just make a .env file, copy and paste what's in the .env.default file into the .env file, and replace the items in angle brackets (<>) with your local setup.

This is still using the example database for now, but the schema should be updated in my next push (hopefully in a couple hours if everything runs smoothly)!